### PR TITLE
Fixed Keybind Issue

### DIFF
--- a/frontend/app/play/_components/MapWrapper.js
+++ b/frontend/app/play/_components/MapWrapper.js
@@ -76,7 +76,7 @@ export default function MapWrapper({ submitGuess, gameState }) {
   const handleKeyDown = (event) => {
     console.log('Key Pressed')
     const key = event.key;
-    if (key === 'Enter') {submitGuess(guess);}
+    if (key === 'Enter' && !dialogOpen) {submitGuess(guess);}
     if (key === 'Escape') {setDialogOpen(false);}
   }
 


### PR DESCRIPTION
Using 'Enter' to submit guess would allow the user to press enter and submit the same guess while the dialog is still open. This has now been corrected with a modification to the condition.